### PR TITLE
Integrate semi-automatic cloud run setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+.local
+cloudbuild.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-slim
 
 ARG BUILDDIR=/home/app/build
-ARG CHECHKOUT_SHA=4beda729b6d07e4669625697ca910697f13af675
+ARG CHECHKOUT_SHA=e5117206fdb84dcb707c8d66367f7b42e552ede4
 
 # Install git
 # Clone repo and checkout specific commit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-slim
 
 ARG BUILDDIR=/home/app/build
-ARG CHECHKOUT_SHA=b8d8f2a1e20d9f84783d4b75c15e04626ce5a602
+ARG CHECHKOUT_SHA=4beda729b6d07e4669625697ca910697f13af675
 
 # Install git
 # Clone repo and checkout specific commit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,26 @@
-FROM node:lts
+FROM node:lts-slim
 
+ARG BUILDDIR=/home/app/build
+ARG CHECHKOUT_SHA=b8d8f2a1e20d9f84783d4b75c15e04626ce5a602
+
+# Install git
 # Clone repo and checkout specific commit
-RUN mkdir -p /home/app \
-    && git clone https://github.com/TypeFox/open-collaboration-tools.git /home/app \
-    && cd /home/app \
-    && git checkout e2503da2e9cfa3ad16c9dbe225f5933074278cda
-
-# Build
-RUN cd /home/app \
+# Then build, copy bundle and clean-up build
+# Remove git again
+RUN apt update \
+    && apt install -y git \
+    && mkdir -p ${BUILDDIR} \
+    && git clone https://github.com/TypeFox/open-collaboration-tools.git ${BUILDDIR} \
+    && cd ${BUILDDIR} \
+    && git checkout ${CHECHKOUT_SHA} \
+    && cd ${BUILDDIR} \
     && npm i \
-    && npm run build
+    && npm run build \
+    && cp ${BUILDDIR}/packages/open-collaboration-server/bundle/app.* /home/app \
+    && rm -fr ${BUILDDIR} \
+    && apt remove -y git \
+    && apt autoremove -y
 
 EXPOSE 8100
 WORKDIR /home/app
-CMD [ "bash", "-c", "npm run start" ]
+CMD [ "bash", "-c", "node /home/app/app.js start --hostname=0.0.0.0" ]

--- a/README.md
+++ b/README.md
@@ -21,36 +21,36 @@ Whenever possible steps are stored in bash scripts which utilize gcloud commands
 
 ## Semi-automatic Preparation
 
-A couple of manual steps are required before the automated part
+A couple of manual steps are required before the automated part.
 
-- [Perform auth login](./scripts/prepare/authLogin.sh). All info is stored in a named container volume, so the info is persisted. [Print auth info](./scripts/prepare/printAuth.sh). You only have to do this once!
-- [Create an env file](./scripts/prepare/createEnvFile.sh) from template in the project's root. Adjust the values accordingly and in the order descibed below (you only have to do this once):
-  - First set the `PROJECT_ID` and:
-    - [Create the project](./scripts/prepare/createProject.sh). It also sets the default project in the local settings.
-  - Use [printBillingAccounts.sh](./scripts/prepare/printBillingAccounts.sh) to retrieve the billing account number and set `BILLING_ACCOUNT_ID` in the env file.
-  - [Enable all required APIs](./scripts/prepare/enableRequiredApis.sh). It requires the billing account previously set.
-  - Use [printRegions.sh](./scripts/prepare/printRegions.sh) to print all regions and set `DEFAULT_REGION` in the env file.
-    - Now [set the default region](./scripts/prepare/setDefaultRegion.sh) in the local config.
-  - Retreive the installation id of the GitHub Cloud Google Cloud Build app here: <https://github.com/settings/installations>. You have to bind this project to this repository. Set the `GITHUB_APP_ID` in the env file.
-  - Update the *GitHub repository* related variables
-  - Adjust OCT environment properties if values are already known. Otherwise, leave as is, because they can be altered and updated later.
-- [Verify the env file](./scripts/prepare/verifyEnvFile.sh)
-- GitHub:
-  - Create a classic access token with all `repo` and `read:user` permissions. If your app is installed in an organization, make sure to also select the `read:org` permission. ([see](https://cloud.google.com/build/docs/automating-builds/github/connect-repo-github?generation=2nd-gen#connecting_a_github_host_programmatically))
-  - Store this token in `<repo-root>/.local/gh.token`. The folder is in contained `.gitignore` and the token can be deleted once it was successfully processed with the next step:
-  - [Store the GitHub token as secret](./scripts/prepare/storeGitHubToken.sh)
+1. *You only have to do this once*: [Perform auth login](./scripts/prepare/authLogin.sh). It will provide a URL you need to paste to browser manually. Once you enter the generated confomation token back in the terminal the process is completed. All info is stored in a named container volume, so the info is persisted and data will be back after container restarts. You can [print auth info with a script](./scripts/prepare/printAuth.sh).
+2. You need to install [Google Cloud Build
+ GitHub App](https://github.com/marketplace/google-cloud-build) in GitHub. Configure the repository the repository that should be used bind to it. Once you did, you need to retrieve the installation id Google Cloud Build app here: <https://github.com/settings/installations>. The id needs to be used in step 3.5. below.
+3. *You only have to do this once*: [Create an env file](./scripts/prepare/createEnvFile.sh) from template in the project's root. Adjust the values accordingly and in the order descibed below:
+    1. First set the `PROJECT_ID` in the env file and save it. Directly [use a script to create the project](./scripts/prepare/createProject.sh) to create a project. It also sets the default project in the local settings.
+    2. Use [printBillingAccounts.sh](./scripts/prepare/printBillingAccounts.sh) to retrieve the billing account number and set `BILLING_ACCOUNT_ID` in the env file.
+    3. [Enable all required APIs](./scripts/prepare/enableRequiredApis.sh). It requires the billing account previously set.
+    4. Use [printRegions.sh](./scripts/prepare/printRegions.sh) to print all regions and set `DEFAULT_REGION` in the env file. Save the env file. [Use another script set the default region](./scripts/prepare/setDefaultRegion.sh) in the local glcoud config.
+    5. Set the `GITHUB_APP_ID` in the env file retrieved in step 2 which will bind the project to the specified repository.
+    6. Update the *GitHub repository* related variables
+    7. Adjust OCT environment properties if values are already known. Otherwise, leave as is, because they can be altered and updated later.
+4. [Verify the env file](./scripts/prepare/verifyEnvFile.sh)
+5. GitHub:
+  4.a. Create a classic access token with all `repo` and `read:user` permissions. If your app is installed in an organization, make sure to also select the `read:org` permission. ([see](https://cloud.google.com/build/docs/automating-builds/github/connect-repo-github?generation=2nd-gen#connecting_a_github_host_programmatically))
+  4.b. Store this token in `<repo-root>/.local/gh.token`. The folder is in contained `.gitignore` and the token can be deleted once it was successfully processed with the next step:
+  4.c. [Store the GitHub token as secret](./scripts/prepare/storeGitHubToken.sh)
 
 ## Setup
 
-You can execute all setup steps one after the other:
+**Either**: Execute all setup steps one after the other:
 
-- [Create new service account and update required permissions](./scripts/setup/updateServiceAccounts.sh)
-- [Create a builds to repo connection](./scripts/setup/createBuildsConnection.sh)
-- [Create a builds repository](./scripts/setup/createBuildsRepository.sh)
-- [Create a docker artifacts repository](./scripts/setup/createArtifactsRepository.sh)
-- [Create a builds trigger](./scripts/setup/createBuildsTrigger.sh)
+1. [Create new service account and update required permissions](./scripts/setup/updateServiceAccounts.sh)
+2. [Create a builds to repo connection](./scripts/setup/createBuildsConnection.sh)
+3. [Create a builds repository](./scripts/setup/createBuildsRepository.sh)
+4. [Create a docker artifacts repository](./scripts/setup/createArtifactsRepository.sh)
+5. [Create a builds trigger](./scripts/setup/createBuildsTrigger.sh)
 
-Or perform them all sequentially with one script:
+**Or**: Perform them all sequentially with one script:
 
 - [Perform all steps](./scripts/performAllSteps.sh)
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,84 @@
+# oct-server-gcloud
+
+Deploy oct server to cloud run with gcloud
+
+## Cloud Build
+
+The easiest way to ensure a stable environment is a container. Please build and start it by utilizing docker compose:
+
+```shell
+docker compose -f dev.docker-compose.yaml build
+docker compose -f dev.docker-compose.yaml up -d
+```
+
+Bash into the container to perform all required setup steps:
+
+```shell
+docker exec -it gcloud-run bash
+```
+
+Whenever possible steps are stored in bash scripts which utilize gcloud commands to perform the required tasks.
+
+## Semi-automatic Preparation
+
+A couple of manual steps are required before the automated part
+
+- [Perform auth login](./scripts/prepare/authLogin.sh). All info is stored in a named container volume, so the info is persisted. [Print auth info](./scripts/prepare/printAuth.sh). You only have to do this once!
+- [Create an env file](./scripts/prepare/createEnvFile.sh) from template in the project's root. Adjust the values accordingly and in the order descibed below (you only have to do this once):
+  - First set the `PROJECT_ID` and:
+    - [Create the project](./scripts/prepare/createProject.sh). It also sets the default project in the local settings.
+  - Use [printBillingAccounts.sh](./scripts/prepare/printBillingAccounts.sh) to retrieve the billing account number and set `BILLING_ACCOUNT_ID` in the env file.
+  - [Enable all required APIs](./scripts/prepare/enableRequiredApis.sh). It requires the billing account previously set.
+  - Use [printRegions.sh](./scripts/prepare/printRegions.sh) to print all regions and set `DEFAULT_REGION` in the env file.
+    - Now [set the default region](./scripts/prepare/setDefaultRegion.sh) in the local config.
+  - Retreive the installation id of the GitHub Cloud Google Cloud Build app here: <https://github.com/settings/installations>. You have to bind this project to this repository. Set the `GITHUB_APP_ID` in the env file.
+  - Update the *GitHub repository* related variables
+  - Adjust OCT environment properties if values are already known. Otherwise, leave as is, because they can be altered and updated later.
+- [Verify the env file](./scripts/prepare/verifyEnvFile.sh)
+- GitHub:
+  - Create a classic access token with all `repo` and `read:user` permissions. If your app is installed in an organization, make sure to also select the `read:org` permission. ([see](https://cloud.google.com/build/docs/automating-builds/github/connect-repo-github?generation=2nd-gen#connecting_a_github_host_programmatically))
+  - Store this token in `<repo-root>/.local/gh.token`. The folder is in contained `.gitignore` and the token can be deleted once it was successfully processed with the next step:
+  - [Store the GitHub token as secret](./scripts/prepare/storeGitHubToken.sh)
+
+## Setup
+
+You can execute all setup steps one after the other:
+
+- [Create new service account and update required permissions](./scripts/setup/updateServiceAccounts.sh)
+- [Create a builds to repo connection](./scripts/setup/createBuildsConnection.sh)
+- [Create a builds repository](./scripts/setup/createBuildsRepository.sh)
+- [Create a docker artifacts repository](./scripts/setup/createArtifactsRepository.sh)
+- [Create a builds trigger](./scripts/setup/createBuildsTrigger.sh)
+
+Or perform them all sequentially with one script:
+
+- [Perform all steps](./scripts/performAllSteps.sh)
+
+## Post setup steps
+
+### Required post step
+
+You have to [enable public access](./scripts/post/enablePublicAccess.sh) to the deployed app. Usage is only possible after first deployment of the app to cloud run.
+
+### Project specific post steps
+
+#### Secrets
+
+Secret can be manually updated here: <https://console.cloud.google.com/security/secret-manager>
+It is higly recommende to update at least the `OCT_JWT_PRIVATE_KEY`. It is the seed for the JWT generator. If not set a default value is created.
+Secrets `OCT_OAUTH_GITHUB_CLIENTID` and `OCT_OAUTH_GITHUB_CLIENTSECRET` are required for GitHub OAtuh support.
+Secrets `OCT_OAUTH_GOOGLE_CLIENTID` and `OCT_OAUTH_GOOGLE_CLIENTSECRET` are required for Google OAuth support.
+
+#### Environment variables
+
+Proper values should be set in the `.env` file in the root of the project. All environment variables are described [here](https://github.com/eclipse-oct/open-collaboration-tools/tree/main/packages/open-collaboration-server#configuration)
+
+#### Update deployed service
+
+Once you updated all secrets and environemnt variables [use this script](./scripts/post/updateServicesVariables.sh) to update the secret to the latest versions and the environment variables for the deployed service.
+
+## Project deletion
+
+If you want to delete the project use the following script:
+
+- [Delete the project](./scripts/remove/removeProject.sh). It can be recovered within the next 30 days.

--- a/config/templates/cloudbuild.template.yaml
+++ b/config/templates/cloudbuild.template.yaml
@@ -1,0 +1,40 @@
+images:
+- $_AR_HOSTNAME/$PROJECT_ID/cloud-run-source-deploy/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA
+options:
+  logging: CLOUD_LOGGING_ONLY
+  substitutionOption: ALLOW_LOOSE
+steps:
+- args:
+  - build
+  - -t
+  - $_AR_HOSTNAME/$PROJECT_ID/cloud-run-source-deploy/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA
+  - .
+  - -f
+  - Dockerfile
+  id: Build
+  name: gcr.io/cloud-builders/docker
+- args:
+  - push
+  - $_AR_HOSTNAME/$PROJECT_ID/cloud-run-source-deploy/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA
+  id: Push
+  name: gcr.io/cloud-builders/docker
+- args:
+  - run
+  - services
+  - update
+  - $_SERVICE_NAME
+  - --image=$_AR_HOSTNAME/$PROJECT_ID/cloud-run-source-deploy/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA
+  - --region=$_DEPLOY_REGION
+  - --service-account=%SERVICE_ACCOUNT%
+  - --port=8100
+  - --cpu=1
+  - --memory=1Gi
+  - --cpu-throttling
+  - --max-instances=1
+  entrypoint: gcloud
+  id: Deploy
+  name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+substitutions:
+  _AR_HOSTNAME: %DEPLOY_REGION%-docker.pkg.dev
+  _DEPLOY_REGION: %DEPLOY_REGION%
+  _SERVICE_NAME: %SERVICE_NAME%

--- a/config/templates/env.template
+++ b/config/templates/env.template
@@ -1,0 +1,48 @@
+# the name of the project
+PROJECT_ID="project-name"
+
+# The default region, use ./scripts/prepare/printRegions.sh
+DEFAULT_REGION="europe-west1"
+
+# The required billing account that needs to be linked to the project
+# You can print all accounts with ./scripts/prepare/printBillingAccounts.sh and enter the correct one here
+BILLING_ACCOUNT_ID="123456-654321-1234B1"
+
+# The installation id of the Google Cloud Build app. You find here https://github.com/settings/installations
+GITHUB_APP_ID=12345678
+
+## GitHub repository (update accordingly)
+
+# The name of the GitHub Repo that contains the Dockerfile
+GITHUB_REPO_NAME=repository_name
+
+# The uri of the GitHub Repo that contains the Dockerfile
+GITHUB_REPO_URI=https://github.com/org_user/repository_name.git
+
+# The name to be used for the Google Cloud to GitHub connection
+GC_GH_CONNECTION_NAME=connection_repository_name
+
+## Presets: no need to change
+
+# Service account name
+SERVICE_ACCOUNT_NAME="cloudbuild-sa"
+
+## Project related environment properties, adjust if known
+
+# Mark as unknown if not known, was: https://api.open-collab.tools
+OCT_BASE_URL="unknown"
+
+# Mark as unknown if not known
+OCT_SERVER_OWNER="unknown"
+
+# default is true
+OCT_ACTIVATE_SIMPLE_LOGIN="true"
+
+# Mark as unknown if not known, was: https://www.open-collab.tools/login
+OCT_LOGIN_PAGE_URL="unknown"
+
+# Mark as unknown if not known, was: https://www.open-collab.tools/login-success
+OCT_LOGIN_SUCCESS_URL="unknown"
+
+# Mark as unknown if not known
+OCT_REDIRECT_URL_WHITELIST="unknown"

--- a/config/templates/env.template
+++ b/config/templates/env.template
@@ -29,20 +29,20 @@ SERVICE_ACCOUNT_NAME="cloudbuild-sa"
 
 ## Project related environment properties, adjust if known
 
-# Mark as unknown if not known, was: https://api.open-collab.tools
+# Set to unknown if not known, was: https://api.open-collab.tools
 OCT_BASE_URL="unknown"
 
-# Mark as unknown if not known
+# Set to unknown if not known
 OCT_SERVER_OWNER="unknown"
 
 # default is true
 OCT_ACTIVATE_SIMPLE_LOGIN="true"
 
-# Mark as unknown if not known, was: https://www.open-collab.tools/login
+# Set to unknown if not known, was: https://www.open-collab.tools/login
 OCT_LOGIN_PAGE_URL="unknown"
 
-# Mark as unknown if not known, was: https://www.open-collab.tools/login-success
+# Set to unknown if not known, was: https://www.open-collab.tools/login-success
 OCT_LOGIN_SUCCESS_URL="unknown"
 
-# Mark as unknown if not known
+# Set to unknown if not known
 OCT_REDIRECT_URL_WHITELIST="unknown"

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,0 +1,7 @@
+FROM google/cloud-sdk:stable
+
+# Prepare environment, create mounted directory and add gcloud completions
+RUN mkdir -p /var/opt/gcloud \
+    && echo "" && echo ". /usr/lib/google-cloud-sdk/completion.bash.inc" >> /root/.bashrc
+
+WORKDIR /var/opt/gcloud

--- a/dev.docker-compose.yaml
+++ b/dev.docker-compose.yaml
@@ -1,0 +1,19 @@
+services:
+  gcloud-run:
+    container_name: gcloud-run
+    image: gcloud-run
+    build:
+      dockerfile: ./dev.Dockerfile
+      context: .
+      platforms:
+        - "linux/amd64"
+    platform: linux/amd64
+    volumes:
+      - ./:/var/opt/gcloud
+      - gcloud-config:/root/.config/gcloud:rw
+    tty: true
+    command: [bash]
+    working_dir: /var/opt/gcloud
+
+volumes:
+  gcloud-config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,6 @@ services:
     ports:
       - 8100:8100
     container_name: oct-server-gce
+    tty: true
+    environment:
+      - OCT_ACTIVATE_SIMPLE_LOGIN=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,11 @@
 services:
-  oct-server-gce:
+  oct-server-local:
     build:
       dockerfile: ./Dockerfile
       context: .
-    image: oct/oct-server-gce
     ports:
       - 8100:8100
-    container_name: oct-server-gce
+    container_name: oct-server-local
     tty: true
     environment:
       - OCT_ACTIVATE_SIMPLE_LOGIN=true

--- a/scripts/performAllSteps.sh
+++ b/scripts/performAllSteps.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+path_cghr=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+. ${path_cghr}/../.env
+
+${path_cghr}/setup/updateServiceAccounts.sh
+
+${path_cghr}/setup/createBuildsConnection.sh
+
+${path_cghr}/setup/createBuildsRepository.sh
+
+${path_cghr}/setup/createArtifactsRepository.sh
+
+${path_cghr}/setup/createBuildsTrigger.sh

--- a/scripts/post/enablePublicAccess.sh
+++ b/scripts/post/enablePublicAccess.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+. $(realpath $(dirname "${BASH_SOURCE[0]}"))/../../.env
+
+# public access
+gcloud run services add-iam-policy-binding ${PROJECT_ID} \
+    --member="allUsers" \
+    --role="roles/run.invoker"

--- a/scripts/post/updateServicesVariables.sh
+++ b/scripts/post/updateServicesVariables.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+path_usv=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+. ${path_usv}/../../.env
+
+${path_usv}/../utils/updateEnvVar.sh "OCT_BASE_URL" "${OCT_BASE_URL}"
+${path_usv}/../utils/updateEnvVar.sh "OCT_SERVER_OWNER" "${OCT_SERVER_OWNER}"
+${path_usv}/../utils/updateEnvVar.sh "OCT_ACTIVATE_SIMPLE_LOGIN" "${OCT_ACTIVATE_SIMPLE_LOGIN}"
+${path_usv}/../utils/updateEnvVar.sh "OCT_LOGIN_PAGE_URL" "${OCT_LOGIN_PAGE_URL}"
+${path_usv}/../utils/updateEnvVar.sh "OCT_LOGIN_SUCCESS_URL" "${OCT_LOGIN_SUCCESS_URL}"
+
+${path_cs}/../utils/createSecret.sh "OCT_JWT_PRIVATE_KEY"
+${path_cs}/../utils/createSecret.sh "OCT_OAUTH_GITHUB_CLIENTID"
+${path_cs}/../utils/createSecret.sh "OCT_OAUTH_GITHUB_CLIENTSECRET"
+${path_cs}/../utils/createSecret.sh "OCT_OAUTH_GOOGLE_CLIENTID"
+${path_cs}/../utils/createSecret.sh "OCT_OAUTH_GOOGLE_CLIENTSECRET"
+
+${path_usv}/../utils/updateSecretVersion.sh "OCT_JWT_PRIVATE_KEY"
+${path_usv}/../utils/updateSecretVersion.sh "OCT_OAUTH_GITHUB_CLIENTID"
+${path_usv}/../utils/updateSecretVersion.sh "OCT_OAUTH_GITHUB_CLIENTSECRET"
+${path_usv}/../utils/updateSecretVersion.sh "OCT_OAUTH_GOOGLE_CLIENTID"
+${path_usv}/../utils/updateSecretVersion.sh "OCT_OAUTH_GOOGLE_CLIENTSECRET"

--- a/scripts/prepare/authLogin.sh
+++ b/scripts/prepare/authLogin.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+gcloud auth login --no-launch-browser

--- a/scripts/prepare/createEnvFile.sh
+++ b/scripts/prepare/createEnvFile.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+path_cef=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+
+if [ -e ${path_cef}/../../.env ]; then
+    echo "Environment file already exists: ${path_cef}/../../.env"
+    exit 1
+else
+    cp ${path_cef}/../../config/templates/env.template ${path_cef}/../../.env
+
+    echo "Created Environment file: ${path_cef}/../../.env"
+fi

--- a/scripts/prepare/createProject.sh
+++ b/scripts/prepare/createProject.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+. $(realpath $(dirname "${BASH_SOURCE[0]}"))/../../.env
+
+# check if project name was given and continue if it is
+found_project=$(gcloud projects list --filter ${PROJECT_ID} | grep ${PROJECT_ID} | wc -l)
+exec_result=$?
+# general error
+if [[ ${exec_result} -eq 1 ]]; then exit 1; fi
+
+if [[ ${found_project} -gt 0 ]]; then
+    echo "Project ${PROJECT_ID} already exists."
+else
+    echo "Project ${PROJECT_ID} does not exists."    
+    
+    echo "Creating project ${PROJECT_ID}..."
+    result=$(gcloud projects create ${PROJECT_ID})
+fi
+
+gcloud config set project ${PROJECT_ID}
+
+gcloud config list

--- a/scripts/prepare/enableRequiredApis.sh
+++ b/scripts/prepare/enableRequiredApis.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+. $(realpath $(dirname "${BASH_SOURCE[0]}"))/../../.env
+
+echo -e "\nEnabling required APIs..."
+
+echo -e "\nEnabling billing for project: ${PROJECT_ID}"
+gcloud billing projects link $PROJECT_ID --billing-account $BILLING_ACCOUNT_ID
+
+echo -e "\nEnabling Cloud Run API"
+gcloud services enable run.googleapis.com
+
+echo -e "\nEnabling Cloud Build API"
+gcloud services enable cloudbuild.googleapis.com
+
+echo -e "\nEnabling Secret Manager API"
+gcloud services enable secretmanager.googleapis.com
+
+echo -e "\nEnabling IAM Credentials API"
+gcloud services enable iamcredentials.googleapis.com

--- a/scripts/prepare/printAuth.sh
+++ b/scripts/prepare/printAuth.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+gcloud auth list

--- a/scripts/prepare/printBillingAccounts.sh
+++ b/scripts/prepare/printBillingAccounts.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+gcloud billing accounts list

--- a/scripts/prepare/printRegions.sh
+++ b/scripts/prepare/printRegions.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+gcloud run regions list

--- a/scripts/prepare/setDefaultRegion.sh
+++ b/scripts/prepare/setDefaultRegion.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+. $(realpath $(dirname "${BASH_SOURCE[0]}"))/../../.env
+
+gcloud config set run/region ${DEFAULT_REGION}
+
+gcloud config list

--- a/scripts/prepare/storeGitHubToken.sh
+++ b/scripts/prepare/storeGitHubToken.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+path_sght=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+. ${path_sght}/../../.env
+
+${path_cs}/../utils/createSecret.sh "GITHUB_TOKEN"
+
+# read GitHub token from local file not under versions control and create a secret
+echo -e "\nChecking if GitHub token secret exists"
+have_version=$(gcloud secrets versions list GITHUB_TOKEN | grep enabled | wc -l)
+if [[ ${have_version} -eq 0 ]]; then
+    echo -e "Creating a secret for GitHub token from: ${path_sght}/../../.local/gh.token"
+    gcloud secrets versions add GITHUB_TOKEN --data-file=${path_sght}/../../.local/gh.token
+    exec_result=$?
+    if [[ ${exec_result} -ne 0 ]]; then
+        echo "Failed to create secret for GitHub token. Please ensure the token is available in: ${path_sght}/../../.local/gh.token"
+        exit 1
+    fi
+else
+    echo "Secret GITHUB_TOKEN is available."
+fi

--- a/scripts/prepare/verifyEnvFile.sh
+++ b/scripts/prepare/verifyEnvFile.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+path_vef=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+. ${path_vef}/../../.env
+
+status=0
+
+${path_vef}/../utils/checkProperty.sh "PROJECT_ID" ${PROJECT_ID}
+status=$((status + $?))
+
+${path_vef}/../utils/checkProperty.sh "BILLING_ACCOUNT_ID" ${BILLING_ACCOUNT_ID}
+status=$((status + $?))
+
+${path_vef}/../utils/checkProperty.sh "SERVICE_ACCOUNT_NAME" ${SERVICE_ACCOUNT_NAME}
+status=$((status + $?))
+
+${path_vef}/../utils/checkProperty.sh "DEFAULT_REGION" ${DEFAULT_REGION}
+status=$((status + $?))
+
+${path_vef}/../utils/checkProperty.sh "GITHUB_REPO_NAME" ${GITHUB_REPO_NAME}
+status=$((status + $?))
+
+${path_vef}/../utils/checkProperty.sh "GITHUB_REPO_URI" ${GITHUB_REPO_URI}
+status=$((status + $?))
+
+${path_vef}/../utils/checkProperty.sh "GITHUB_APP_ID" ${GITHUB_APP_ID}
+status=$((status + $?))
+
+${path_vef}/../utils/checkProperty.sh "GC_GH_CONNECTION_NAME" ${GC_GH_CONNECTION_NAME}
+status=$((status + $?))
+
+${path_vef}/../utils/checkProperty.sh "OCT_BASE_URL" ${OCT_BASE_URL}
+status=$((status + $?))
+
+${path_vef}/../utils/checkProperty.sh "OCT_SERVER_OWNER" ${OCT_SERVER_OWNER}
+status=$((status + $?))
+
+${path_vef}/../utils/checkProperty.sh "OCT_ACTIVATE_SIMPLE_LOGIN" ${OCT_ACTIVATE_SIMPLE_LOGIN}
+status=$((status + $?))
+
+${path_vef}/../utils/checkProperty.sh "OCT_LOGIN_PAGE_URL" ${OCT_LOGIN_PAGE_URL}
+status=$((status + $?))
+
+${path_vef}/../utils/checkProperty.sh "OCT_LOGIN_SUCCESS_URL" ${OCT_LOGIN_SUCCESS_URL}
+status=$((status + $?))
+
+${path_vef}/../utils/checkProperty.sh "OCT_REDIRECT_URL_WHITELIST" ${OCT_REDIRECT_URL_WHITELIST}
+status=$((status + $?))
+
+if [[ ${status} -eq 0 ]]; then
+    echo "Environment file contains all required key value pairs."
+else
+    echo "Environment file is not valid. Check the printed errors."
+fi

--- a/scripts/remove/removeProject.sh
+++ b/scripts/remove/removeProject.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+. $(realpath $(dirname "${BASH_SOURCE[0]}"))/../../.env
+
+echo "Removing project: ${PROJECT_ID}."
+echo "You can undelete within the next 30 days."
+
+gcloud projects delete ${PROJECT_ID}

--- a/scripts/setup/createArtifactsRepository.sh
+++ b/scripts/setup/createArtifactsRepository.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+. $(realpath $(dirname "${BASH_SOURCE[0]}"))/../../.env
+
+echo -e "\nCreating Artifacts repository..."
+
+default_repo_name="cloud-run-source-deploy"
+repo_exists=$(gcloud artifacts repositories list --location=${DEFAULT_REGION} | grep ${default_repo_name} | wc -l)
+if [[ ${repo_exists} -eq 0 ]]; then
+    echo "Creating artifacts repository: ${default_repo_name}"
+    gcloud artifacts repositories create ${default_repo_name} \
+        --repository-format="docker" \
+        --location=${DEFAULT_REGION} \
+        --description="Docker repository"
+else
+    echo "Artifacts repository already exists: ${default_repo_name}"
+fi

--- a/scripts/setup/createBuildsConnection.sh
+++ b/scripts/setup/createBuildsConnection.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+. $(realpath $(dirname "${BASH_SOURCE[0]}"))/../../.env
+
+echo -e "\nCreating Builds to repository connection..."
+
+# update versions
+secret_versions=$(gcloud secrets versions list GITHUB_TOKEN | grep enabled)
+exec_result=$?
+
+connection_exists=$(gcloud builds connections list --region ${DEFAULT_REGION} | grep ${GC_GH_CONNECTION_NAME} | wc -l)
+if [[ ${connection_exists} -eq 0 && ${exec_result} -eq 0 ]]; then
+    # take the latest version
+    read -a versions_array <<< "${secret_versions}"
+    active_secret_version="${versions_array[0]}"
+
+    echo "Creating GitHub connection: ${GC_GH_CONNECTION_NAME}"
+    gcloud builds connections create github ${GC_GH_CONNECTION_NAME} \
+        --authorizer-token-secret-version=projects/${PROJECT_ID}/secrets/GITHUB_TOKEN/versions/${active_secret_version} \
+        --app-installation-id=${GITHUB_APP_ID} \
+        --region=${DEFAULT_REGION}
+else
+    echo "GitHub connection already exists: ${GC_GH_CONNECTION_NAME}"
+fi

--- a/scripts/setup/createBuildsRepository.sh
+++ b/scripts/setup/createBuildsRepository.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+. $(realpath $(dirname "${BASH_SOURCE[0]}"))/../../.env
+
+echo -e "\nCreating Builds repository..."
+
+repo_exists=$(gcloud builds repositories list --region ${DEFAULT_REGION} --connection ${GC_GH_CONNECTION_NAME} | grep ${GITHUB_REPO_NAME} | wc -l)
+if [[ ${repo_exists} -eq 0 ]]; then
+    echo "Creating builds repository: ${GITHUB_REPO_NAME}"
+    gcloud builds repositories create  ${GITHUB_REPO_NAME} \
+        --remote-uri=${GITHUB_REPO_URI} \
+        --connection=${GC_GH_CONNECTION_NAME} \
+        --region=${DEFAULT_REGION}
+else
+    echo "Builds repository already exists: ${GITHUB_REPO_NAME}"
+fi

--- a/scripts/setup/createBuildsTrigger.sh
+++ b/scripts/setup/createBuildsTrigger.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+path_cbt=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+. ${path_cbt}/../../.env
+
+echo -e "\nCreating a build trigger for GitHub app"
+
+service_account=${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com
+
+# Create cloudbuild.yaml by replacing placeholders in cloudbuild.template.yaml
+sed "s/%DEPLOY_REGION%/${DEFAULT_REGION}/g" ${path_cbt}/../../config/templates/cloudbuild.template.yaml > ${path_cbt}/../../cloudbuild.tmp
+sed "s/%SERVICE_NAME%/${PROJECT_ID}/g" ${path_cbt}/../../cloudbuild.tmp > ${path_cbt}/../../cloudbuild.yaml
+mv ${path_cbt}/../../cloudbuild.yaml ${path_cbt}/../../cloudbuild.tmp
+sed "s/%SERVICE_ACCOUNT%/${service_account}/g" ${path_cbt}/../../cloudbuild.tmp > ${path_cbt}/../../cloudbuild.yaml
+rm ${path_cbt}/../../cloudbuild.tmp
+
+trigger_name="${GITHUB_REPO_NAME}-trigger"
+needs_trigger=$(gcloud builds triggers list --region="${DEFAULT_REGION}" | grep -i ${trigger_name} | wc -l)
+
+repo_path="projects/${PROJECT_ID}/locations/${DEFAULT_REGION}/connections/${GC_GH_CONNECTION_NAME}/repositories/${GITHUB_REPO_NAME}"
+if [[ ${needs_trigger} -eq 0 ]]; then
+    echo "Creating trigger: ${trigger_name} for: ${repo_path}"
+    gcloud builds triggers create github --name="${trigger_name}" \
+        --repository="${repo_path}" \
+        --branch-pattern="^main$" \
+        --inline-config=${path_cbt}/../../cloudbuild.yaml \
+        --region="${DEFAULT_REGION}" \
+        --service-account="projects/${PROJECT_ID}/serviceAccounts/${service_account}"
+else
+    echo "Trigger '${trigger_name}' for '${repo_path}' already exists."
+fi

--- a/scripts/setup/updateServiceAccounts.sh
+++ b/scripts/setup/updateServiceAccounts.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+path_csa=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+. ${path_csa}/../../.env
+
+# https://cloud.google.com/iam/docs/service-accounts-create
+
+service_account=${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com
+sa_exists=$(gcloud iam service-accounts list | grep ${SERVICE_ACCOUNT_NAME} | wc -l)
+PN=$(gcloud projects list --filter="${PROJECT_ID}" --format="value(PROJECT_NUMBER)")
+
+if [[ ${sa_exists} -eq 0 ]]; then
+    echo "Creating service account: ${service_account}"
+    result=$(gcloud iam service-accounts create ${SERVICE_ACCOUNT_NAME} \
+        --display-name="Cloud Build Service Account" \
+        --description="Cloud Build Service Account")
+else
+    echo "Service account '${service_account}' already exists."
+fi
+
+# Needed for "gcloud builds connections create github" (createBuildsConnection.sh)
+${path_csa}/../utils/addIamPolicy.sh "roles/secretmanager.secretAccessor" "service-${PN}@gcp-sa-cloudbuild.iam.gserviceaccount.com"
+
+# general permissions for build, push, deploy (=run service update)
+${path_csa}/../utils/addIamPolicy.sh "roles/logging.logWriter" ${service_account}
+${path_csa}/../utils/addIamPolicy.sh "roles/artifactregistry.writer" ${service_account}
+${path_csa}/../utils/addIamPolicy.sh "roles/run.admin" ${service_account}
+${path_csa}/../utils/addIamPolicy.sh "roles/run.serviceAgent" ${service_account}

--- a/scripts/utils/addIamPolicy.sh
+++ b/scripts/utils/addIamPolicy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+. $(realpath $(dirname "${BASH_SOURCE[0]}"))/../../.env
+
+role_required=${1}
+account_name=${2}
+
+echo -e "\nChecking '${account_name}' for IAM permissions. Required role: ${role_required}"
+needs_iam_policy=$(gcloud projects get-iam-policy ${PROJECT_ID} | grep -B 2 ${role_required} | grep ${account_name} | wc -l)
+if [[ ${needs_iam_policy} -eq 0 ]]; then
+    echo "Updating IAM policy '${role_required}' for: ${account_name}"
+    gcloud projects add-iam-policy-binding ${PROJECT_ID} \
+        --member="serviceAccount:${account_name}" \
+        --role=${role_required}
+else
+    echo "No IAM policy '${role_required}' update needed for: ${account_name}"
+fi

--- a/scripts/utils/checkProperty.sh
+++ b/scripts/utils/checkProperty.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+key=${1}
+value=${2}
+
+if [[ -n "${value// /}" ]]; then  
+    echo "${key} is set to: ${value}"    
+    exit 0
+else
+    echo "Error: ${key} is not set."
+    exit 1
+fi

--- a/scripts/utils/createSecret.sh
+++ b/scripts/utils/createSecret.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+. $(realpath $(dirname "${BASH_SOURCE[0]}"))/../../.env
+
+secret_name=${1}
+
+secrets_list=$(gcloud secrets list)
+have_secret=$(echo $secrets_list | grep ${secret_name} | wc -l)
+
+if [[ ${have_secret} -eq 0 ]]; then
+    echo "Creating secret: ${secret_name}"
+    gcloud secrets create ${secret_name} --replication-policy="automatic"
+else
+    echo "Secret ${secret_name} already exists."
+fi

--- a/scripts/utils/removeIamPolicy.sh
+++ b/scripts/utils/removeIamPolicy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+. $(realpath $(dirname "${BASH_SOURCE[0]}"))/../../.env
+
+role_required=${1}
+account_name=${2}
+
+echo -e "\nChecking '${account_name}' for IAM permissions. Required role: ${role_required}"
+iam_policy_removal_needed=$(gcloud projects get-iam-policy ${PROJECT_ID} | grep -B 2 ${role_required} | grep ${account_name} | wc -l)
+if [[ ${iam_policy_removal_needed} -eq 1 ]]; then
+    echo "Removing IAM policy '${role_required}' for: ${account_name}"
+    gcloud projects remove-iam-policy-binding ${PROJECT_ID} \
+        --member="serviceAccount:${account_name}" \
+        --role=${role_required}
+else
+    echo "No IAM policy '${role_required}' found for: ${account_name}"
+fi

--- a/scripts/utils/updateEnvVar.sh
+++ b/scripts/utils/updateEnvVar.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+. $(realpath $(dirname "${BASH_SOURCE[0]}"))/../../.env
+
+var_name=${1}
+var_value=${2}
+
+if [[ "${var_value}" != "unknown" ]]; then
+  echo "Updating ${var_name} to: ${var_value}"
+  gcloud run services update ${PROJECT_ID} --update-env-vars=${var_name}=${var_value}
+else
+  echo "${var_name} has default value: ${var_value}"
+fi

--- a/scripts/utils/updateSecretVersion.sh
+++ b/scripts/utils/updateSecretVersion.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+. $(realpath $(dirname "${BASH_SOURCE[0]}"))/../../.env
+
+secret_name=${1}
+
+secret_versions=$(gcloud secrets versions list ${secret_name} | grep enabled)
+exec_result=$?
+
+if [[ ${exec_result} -eq 0 ]]; then
+    # take the latest version
+    read -a versions_array <<< "${secret_versions}"
+    active_secret_version="${versions_array[0]}"
+
+    echo "Updating secret '${secret_name}' to version: ${have_version}"
+    gcloud run services update ${PROJECT_ID} --update-secrets=${secret_name}=${secret_name}:${active_secret_version}
+else
+    echo "No version available for secret: ${secret_name}"
+fi


### PR DESCRIPTION
The README.md is the documentation. 🙂 As described use dev.docker-compose.yaml for using all scripts.

It took some wrong turns regarding the service accounts during development and burned multiple hours finding out why things did not work when I retested what I had created on fresh project (2nd out of four iterations, the last three happened yesterday 🙈 ). Long story short: Use the default service accounts wherever possible and enhance their IAM policies slightly (e.g. for secret resolution) and use your own service account (with minimally needed permission) for build, deploy and run.

Next time I will use the TypeScript based node packages instead of bash scripts + glcoud cli. The required steps are needed independent of the technical implemtation.